### PR TITLE
Fixes a crash and some missing lore issues

### DIFF
--- a/src/main/java/dmillerw/lore/LoreExpansion.java
+++ b/src/main/java/dmillerw/lore/LoreExpansion.java
@@ -12,6 +12,7 @@ import cpw.mods.fml.common.registry.GameRegistry;
 import dmillerw.lore.common.command.CommandLore;
 import dmillerw.lore.common.core.GuiHandler;
 import dmillerw.lore.common.core.handler.DefaultFileHandler;
+import dmillerw.lore.common.core.handler.PlayerSpawnHandler;
 import dmillerw.lore.common.core.handler.PlayerTickHandler;
 import dmillerw.lore.common.item.ItemJournal;
 import dmillerw.lore.common.item.ItemLorePage;
@@ -19,6 +20,8 @@ import dmillerw.lore.common.lore.LoreLoader;
 import dmillerw.lore.common.network.NetworkEventHandler;
 import dmillerw.lore.common.network.packet.PacketHandler;
 import net.minecraft.item.Item;
+import net.minecraftforge.common.MinecraftForge;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -83,12 +86,14 @@ public class LoreExpansion {
 
     @Mod.EventHandler
     public void init(FMLInitializationEvent event) {
-        NetworkRegistry.INSTANCE.registerGuiHandler(this, new GuiHandler());
+    	NetworkRegistry.INSTANCE.registerGuiHandler(this, new GuiHandler());
     }
 
     @Mod.EventHandler
     public void postInit(FMLPostInitializationEvent event) {
         proxy.postInit(event);
+
+        MinecraftForge.EVENT_BUS.register(new PlayerSpawnHandler());
     }
 
     @Mod.EventHandler

--- a/src/main/java/dmillerw/lore/common/core/handler/PlayerSpawnHandler.java
+++ b/src/main/java/dmillerw/lore/common/core/handler/PlayerSpawnHandler.java
@@ -1,0 +1,37 @@
+package dmillerw.lore.common.core.handler;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.event.entity.EntityEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.relauncher.Side;
+import dmillerw.lore.common.lore.PlayerHandler;
+
+public class PlayerSpawnHandler {
+
+	@SubscribeEvent
+	public void onEntityConstructing(EntityEvent.EntityConstructing event) {
+		Side side = FMLCommonHandler.instance().getEffectiveSide();
+		if (side == Side.SERVER) {
+			if (event.entity instanceof EntityPlayer) {
+				PlayerHandler.attach((EntityPlayer) event.entity);
+			}
+		}
+	}
+
+	@SubscribeEvent
+	public void onPlayerClone(PlayerEvent.Clone event) {
+		// When the player dies and is respawned, NBT data associated with its old entity is lost.
+		// This will copy the data from the old entity to the new one.
+		Side side = FMLCommonHandler.instance().getEffectiveSide();
+		if (side == Side.SERVER) {
+			NBTTagCompound temp = new NBTTagCompound();
+			PlayerHandler.getCollectedLore( event.original ).saveNBTData(temp);
+			PlayerHandler.attach(event.entityPlayer);
+			PlayerHandler.getCollectedLore(event.entityPlayer).loadNBTData(temp);
+		}
+	}
+
+}

--- a/src/main/java/dmillerw/lore/common/network/NetworkEventHandler.java
+++ b/src/main/java/dmillerw/lore/common/network/NetworkEventHandler.java
@@ -1,23 +1,26 @@
 package dmillerw.lore.common.network;
 
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
 import cpw.mods.fml.relauncher.Side;
 import dmillerw.lore.common.lore.PlayerHandler;
-import net.minecraft.entity.player.EntityPlayer;
+import dmillerw.lore.common.network.packet.PacketSyncLore;
 
 /**
  * @author dmillerw
  */
+
 public class NetworkEventHandler {
 
-    @SubscribeEvent
-    public void playerLoggedInEvent(PlayerEvent.PlayerLoggedInEvent event) {
-        EntityPlayer player = event.player;
-        Side side = FMLCommonHandler.instance().getEffectiveSide();
-        if (side == Side.SERVER) {
-            PlayerHandler.attach(player);
-        }
-    }
+	@SubscribeEvent
+	public void playerLoggedInEvent(PlayerEvent.PlayerLoggedInEvent event) {
+		EntityPlayer player = event.player;
+		Side side = FMLCommonHandler.instance().getEffectiveSide();
+		if (side == Side.SERVER) {
+			PacketSyncLore.updateLore((EntityPlayerMP) player);
+		}
+	}
 }


### PR DESCRIPTION
Fixes:
- lore lost after death
- crash on lore pickup after respawn
- acquired pages not synced after restarting the game
- acquired pages persist into separate saved games