### PR TITLE
Add a null check in case the command json entry is completely missing.

### DIFF
--- a/src/main/java/dmillerw/lore/common/core/handler/PlayerTickHandler.java
+++ b/src/main/java/dmillerw/lore/common/core/handler/PlayerTickHandler.java
@@ -63,13 +63,15 @@ public class PlayerTickHandler {
                                     PacketNotification.notify(event.player, PacketNotification.TYPE_CLIENT_AUTOPLAY, key);
                                 }
 
-                                for (Commands.CommandEntry command : lore.commands.commands) {
-                                    if (command.delay > 0) {
-                                        CommandDelayHandler.queueCommand(event.player, command);
-                                    } else {
-                                        CommandHandler ch = (CommandHandler) MinecraftServer.getServer().getCommandManager();
-                                        LoreCommandSender commandSender = new LoreCommandSender(event.player);
-                                        ch.executeCommand(commandSender, command.command);
+                                if (lore.commands.commands != null) {
+                                    for (Commands.CommandEntry command : lore.commands.commands) {
+                                        if (command.delay > 0) {
+                                            CommandDelayHandler.queueCommand(event.player, command);
+                                        } else {
+                                            CommandHandler ch = (CommandHandler) MinecraftServer.getServer().getCommandManager();
+                                            LoreCommandSender commandSender = new LoreCommandSender(event.player);
+                                            ch.executeCommand(commandSender, command.command);
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
@CyanideX reported this null pointer exception http://paste.ee/p/hB7Ej

I've tracked it down to when the JSON for lore does not contain a {command: []} block in the JSON.
I've added a null check to prevent this from taking out the game.